### PR TITLE
Add value for `new_dnu` when pressed key is something other than `left` or `right`

### DIFF
--- a/echelle/echelle.py
+++ b/echelle/echelle.py
@@ -221,6 +221,9 @@ def interact_echelle(freq, power, dnu_min, dnu_max, step=0.01,
             new_dnu = slider.val - slider.valstep
         elif event.key == 'right':
             new_dnu = slider.val + slider.valstep
+        else:
+            new_dnu = slider.val
+
         slider.set_val(new_dnu)
         update(new_dnu)   
         


### PR DESCRIPTION
In IPython, if I press keys other than `←` or `→` (e.g. keyboard shortcuts like `g` to toggle the grid), I get error messages on the console like

````Python
Traceback (most recent call last):
  File "/home/wball/.local/lib/python3.7/site-packages/matplotlib/cbook/__init__.py", line 216, in process
    func(*args, **kwargs)
  File "/home/wball/.local/lib/python3.7/site-packages/echelle/echelle.py", line 225, in on_key_press
    slider.set_val(new_dnu)
UnboundLocalError: local variable 'new_dnu' referenced before assignment
````
I realise Jupyter Notebooks are the intended use but this is a two-line fix for dinosaurs like me who don't use them.
