### PR TITLE
Don't print valfmt in interact.py

### DIFF
--- a/echelle/interact.py
+++ b/echelle/interact.py
@@ -117,7 +117,7 @@ def interact_echelle(
         
         axfreq = plt.axes([0.1, 0.025, 0.8, 0.02])
         valfmt = "%1." + str(len(str(step).split(".")[-1])) + "f"
-        print(valfmt)
+
         slider = Slider(
             axfreq,
             u"\u0394\u03BD",


### PR DESCRIPTION
I noticed myself getting statements like "%1.16f" on the terminal when using echelle as part of another program and I traced it back to this one line change. I presume it was only there for debugging purposes; this PR removes it.